### PR TITLE
Lets one render the same component many times

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,9 +265,9 @@ hypernova({
 
 ```typescript
 type DeserializedData = { [x: string]: any };
-type Node = { node: HTMLElement, data: DeserializedData };
+type ServerRenderedPair = { node: HTMLElement, data: DeserializedData };
 
-function load(name: string): Node {}
+function load(name: string): Array<ServerRenderedPair> {}
 ```
 
 Looks up the server-rendered DOM markup and its corresponding `script` JSON payload and returns it.
@@ -297,10 +297,11 @@ An interface that allows you to create extra `script` tags for loading more data
 ```typescript
 type DeserializedData = { [x: string]: any };
 
-function fromScript(attr: string, key: string): DeserializedData {}
+function fromScript(attr: string, key: string, id: string): DeserializedData {}
 ```
 
 The inverse of `toScript`, this function runs on the browser and attempts to find and `JSON.parse` the contents of the server generated script.
+`attr` is a custom data attribute that is included in the HTML element, `key` is the data attribute's value and will be used to find the element on the browser, `id` is optional and if included will attempt to find the DOM node with `data-hypernova-id="${id}"`.
 
 ### Server
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,22 @@ const ENCODE = [
   ['>', '&gt;'],
 ];
 
+const DATA_KEY = 'hypernova-key';
+
+// https://gist.github.com/jed/982883
+function uuid() {
+  return (
+    [1e7] +
+    -1e3 +
+    -4e3 +
+    -8e3 +
+    -1e11
+  ).replace(
+    /[018]/g,
+    x => (x ^ Math.random() * 16 >> x / 4).toString(16)
+  );
+}
+
 function encode(obj) {
   return ENCODE.reduce((str, coding) => {
     const [encodeChar, htmlEntity] = coding;
@@ -22,35 +38,36 @@ function decode(res) {
   return JSON.parse(jsonPayload);
 }
 
-function backwardCompat(node, attr, key) {
-  return `${node}[data-mystique-key="${key}"],${node}[data-${attr}="${key}"]`;
+function toScript(attr, key, props, id) {
+  return `<script type="application/json" data-${attr}="${key}" data-hypernova-id=${id}>${LEFT}${encode(props)}${RIGHT}</script>`; // eslint-disable-line max-len
 }
 
-function toScript(attr, key, props) {
-  return `<script type="application/json" data-${attr}="${key}">${LEFT}${encode(props)}${RIGHT}</script>`; // eslint-disable-line max-len
-}
-
-function fromScript(attr, key) {
-  const node = document.querySelector(backwardCompat('script', attr, key));
+function fromScript(attr, key, id) {
+  const idSelector = id ? `[data-hypernova-id="${id}"]` : '';
+  const node = document.querySelector(`script[data-${attr}="${key}"]${idSelector}`);
   if (!node) return null;
   const jsonPayload = node.innerHTML;
+
   return decode(jsonPayload.slice(LEFT.length, jsonPayload.length - RIGHT.length));
 }
 
 function serialize(name, html, data) {
   const key = name.replace(/\W/g, '');
-  const markup = `<div data-hypernova-key="${key}">${html}</div>`;
-  const script = toScript('hypernova-key', key, data);
+  const id = uuid();
+  const markup = `<div data-${DATA_KEY}="${key}" data-hypernova-id=${id}>${html}</div>`;
+  const script = toScript(DATA_KEY, key, data, id);
   return `${markup}\n${script}`;
 }
 
 function load(name) {
   const key = name.replace(/\W/g, '');
-  const node = document.querySelector(backwardCompat('div', 'hypernova-key', key));
-  if (!node) return {};
+  const nodes = document.querySelectorAll(`div[data-${DATA_KEY}="${key}"]`);
 
-  const data = fromScript('hypernova-key', key);
-  return { node, data };
+  return Array.prototype.map.call(nodes, (node) => {
+    const id = node.getAttribute('data-hypernova-id');
+    const data = fromScript(DATA_KEY, key, id);
+    return { node, data };
+  });
 }
 
 export default function hypernova(runner) {


### PR DESCRIPTION
This would be a `major` version.

Currently it's impossible to render the same component many times on the page (you can only do this if your entry bundle has different keys) and this is because the key you use to render a component must be unique.

This adds a `data-hypernova-id` attribute to server-rendered markup. The value of this key is a generated unique id which will match the script contents to the markup. This makes it possible to use the same component on the page multiple times.

A few API changes:

* `fromScript` now takes a 3rd argument, an `id`. If it is present it queries for the matching key and id.
* `load` now returns an Array of `{ node, data }` where previously it only returned `{ node, data }`. If no elements were found while querying then the Array will be empty (previously it returned null).

Also in this PR, I've removed the `backwardCompat` thing since we don't need it any more.

TODO

- [x] The API needs docs.

@ljharb 