### PR TITLE
Lets one render the same component many times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- `toScript` function signature changed. It now expects an object of data attributes to value.
+
+  ```js
+  // before
+  toScript('foo', 'bar', { hello: 'world' })
+
+  // now
+  toScript({ foo: 'bar' }, { hello: 'world' })
+  ```
+
+- `fromScript` function signature changed.
+
+  ```js
+  // before
+  fromScript('foo', 'bar')
+
+  // now
+  fromScript({ foo: 'bar' })
+  ```
+
 ## [1.2.0] - 2016-09-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -286,8 +286,9 @@ Generates the markup that the browser will need to bootstrap your view on the br
 
 ```typescript
 type DeserializedData = { [x: string]: any };
+type Attributes = { [x: string]: string };
 
-function toScript(attr: string, key: string, props: DeserializedData): string {}
+function toScript(attrs: Attributes, props: DeserializedData): string {}
 ```
 
 An interface that allows you to create extra `script` tags for loading more data on the browser.
@@ -296,12 +297,13 @@ An interface that allows you to create extra `script` tags for loading more data
 
 ```typescript
 type DeserializedData = { [x: string]: any };
+type Attributes = { [x: string]: string };
 
-function fromScript(attr: string, key: string, id: string): DeserializedData {}
+function fromScript(attrs: Attributes): DeserializedData {}
 ```
 
 The inverse of `toScript`, this function runs on the browser and attempts to find and `JSON.parse` the contents of the server generated script.
-`attr` is a custom data attribute that is included in the HTML element, `key` is the data attribute's value and will be used to find the element on the browser, `id` is optional and if included will attempt to find the DOM node with `data-hypernova-id="${id}"`.
+`attrs` is an object where the key will be a `data-key` to be placed on the element, and the value is the data attribute's value.
 
 ### Server
 

--- a/README.md
+++ b/README.md
@@ -265,9 +265,9 @@ hypernova({
 
 ```typescript
 type DeserializedData = { [x: string]: any };
-type Node = { node: HTMLElement, data: DeserializedData };
+type ServerRenderedPair = { node: HTMLElement, data: DeserializedData };
 
-function load(name: string): Node {}
+function load(name: string): Array<ServerRenderedPair> {}
 ```
 
 Looks up the server-rendered DOM markup and its corresponding `script` JSON payload and returns it.
@@ -297,10 +297,11 @@ An interface that allows you to create extra `script` tags for loading more data
 ```typescript
 type DeserializedData = { [x: string]: any };
 
-function fromScript(attr: string, key: string): DeserializedData {}
+function fromScript(attr: string, key: string, id: string): DeserializedData {}
 ```
 
 The inverse of `toScript`, this function runs on the browser and attempts to find and `JSON.parse` the contents of the server generated script.
+`attr` is a custom data attribute that is included in the HTML element, `key` is the data attribute's value and will be used to find the element on the browser, `id` is optional and if included will attempt to find the DOM node with `data-hypernova-id="${id}"`.
 
 ### Server
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ function uuid() {
     -1e11
   ).replace(
     /[018]/g,
-    x => (x ^ Math.random() * 16 >> x / 4).toString(16)
+    x => (x ^ Math.random() * 16 >> x / 4).toString(16) // eslint-disable-line no-mixed-operators
   );
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,22 @@ const ENCODE = [
   ['>', '&gt;'],
 ];
 
+const DATA_KEY = 'hypernova-key';
+
+// https://gist.github.com/jed/982883
+function uuid() {
+  return (
+    [1e7] +
+    -1e3 +
+    -4e3 +
+    -8e3 +
+    -1e11
+  ).replace(
+    /[018]/g,
+    x => (x ^ Math.random() * 16 >> x / 4).toString(16)
+  );
+}
+
 function encode(obj) {
   return ENCODE.reduce((str, coding) => {
     const [encodeChar, htmlEntity] = coding;
@@ -24,35 +40,36 @@ function decode(res) {
   return JSON.parse(jsonPayload);
 }
 
-function backwardCompat(node, attr, key) {
-  return `${node}[data-mystique-key="${key}"],${node}[data-${attr}="${key}"]`;
+function toScript(attr, key, props, id) {
+  return `<script type="application/json" data-${attr}="${key}" data-hypernova-id=${id}>${LEFT}${encode(props)}${RIGHT}</script>`; // eslint-disable-line max-len
 }
 
-function toScript(attr, key, props) {
-  return `<script type="application/json" data-${attr}="${key}">${LEFT}${encode(props)}${RIGHT}</script>`; // eslint-disable-line max-len
-}
-
-function fromScript(attr, key) {
-  const node = document.querySelector(backwardCompat('script', attr, key));
+function fromScript(attr, key, id) {
+  const idSelector = id ? `[data-hypernova-id="${id}"]` : '';
+  const node = document.querySelector(`script[data-${attr}="${key}"]${idSelector}`);
   if (!node) return null;
   const jsonPayload = node.innerHTML;
+
   return decode(jsonPayload.slice(LEFT.length, jsonPayload.length - RIGHT.length));
 }
 
 function serialize(name, html, data) {
   const key = name.replace(/\W/g, '');
-  const markup = `<div data-hypernova-key="${key}">${html}</div>`;
-  const script = toScript('hypernova-key', key, data);
+  const id = uuid();
+  const markup = `<div data-${DATA_KEY}="${key}" data-hypernova-id=${id}>${html}</div>`;
+  const script = toScript(DATA_KEY, key, data, id);
   return `${markup}\n${script}`;
 }
 
 function load(name) {
   const key = name.replace(/\W/g, '');
-  const node = document.querySelector(backwardCompat('div', 'hypernova-key', key));
-  if (!node) return {};
+  const nodes = document.querySelectorAll(`div[data-${DATA_KEY}="${key}"]`);
 
-  const data = fromScript('hypernova-key', key);
-  return { node, data };
+  return Array.prototype.map.call(nodes, (node) => {
+    const id = node.getAttribute('data-hypernova-id');
+    const data = fromScript(DATA_KEY, key, id);
+    return { node, data };
+  });
 }
 
 export default function hypernova(runner) {

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -9,7 +9,7 @@ function cheerioToDOM($, className) {
     const node = cheerioObj;
     node.nodeName = node.name.toUpperCase();
     node.innerHTML = $(node).html();
-    node.getAttribute = () => '';
+    node.getAttribute = attr => $(node).data(attr.replace('data-', ''));
     return node;
   })[0];
 }

--- a/test/escape-test.js
+++ b/test/escape-test.js
@@ -32,7 +32,7 @@ describe('escaping', () => {
     });
 
     it('escapes multiple times the same, with interleaved decoding', () => {
-      const makeHTML = () => toScript('attr', 'key', {
+      const makeHTML = () => toScript({ attr: 'key' }, {
         props: 'yay',
         needsEncoding: '" &gt; </script>', // "needsEncoding" is necessary
       });
@@ -44,7 +44,7 @@ describe('escaping', () => {
 
       global.document.querySelector = () => ({ innerHTML: $($('script')[0]).html() });
 
-      const res = fromScript('attr', 'key');
+      const res = fromScript({ attr: 'key' });
 
       const script3 = makeHTML();
       assert.equal(

--- a/test/escape-test.js
+++ b/test/escape-test.js
@@ -15,12 +15,14 @@ describe('escaping', () => {
   .withGlobal('document', () => ({}))
   .describe('with fromScript', () => {
     it('loads the escaped content correctly', () => {
-      const html = toScript('a', 'b', { foo: '</script>', bar: '&gt;', baz: '&amp;' });
+      const html = toScript({ a: 'b' }, { foo: '</script>', bar: '&gt;', baz: '&amp;' });
       const $ = cheerio.load(html);
 
       global.document.querySelector = () => ({ innerHTML: $($('script')[0]).html() });
 
-      const res = fromScript('a', 'b');
+      const res = fromScript({
+        a: 'b',
+      });
 
       assert.isObject(res);
 
@@ -55,5 +57,33 @@ describe('escaping', () => {
 
       assert.equal(res.props, 'yay');
     });
+  });
+
+  it('escapes quotes and fixes data attributes', () => {
+    const markup = toScript({
+      'ZOMG-ok': 'yes',
+      'data-x': 'y',
+      '1337!!!': 'w00t',
+      '---valid': '',
+      'Is this ok?': '',
+      'weird-values': '"]<script>alert(1);</script>',
+      'weird-values2': '"&quot;"',
+    }, {});
+
+    const $ = cheerio.load(markup);
+    const $node = $('script');
+
+    assert.isString($node.data('zomg-ok'));
+    assert.isString($node.data('data-x'));
+    assert.isString($node.data('1337'));
+    assert.isString($node.data('---valid'));
+    assert.isString($node.data('isthisok'));
+
+    assert.equal($node.data('weird-values'), '"]<script>alert(1);</script>');
+    assert.equal($node.data('weird-values2'), '"&quot;"');
+
+    assert.isUndefined($node.data('ZOMG-ok'));
+    assert.isUndefined($node.data('x'));
+    assert.isUndefined($node.data('Is this ok?'));
   });
 });


### PR DESCRIPTION
Piggybacks off of #10 

Main change here is that we're changing `fromScript` and `toScript` to only accept an object which maps its keys => data attribute, and value => data attribute's value. The data attributes will be encoded to make sure they're lower-case and only contain alphanumeric + `-`. The value is encoded as well as it encodes quotes so that selecting won't break with arbitrary inputs.

@ljharb 