### PR TITLE
Allows non instanceOf Error to be thrown

### DIFF
--- a/src/utils/BatchManager.js
+++ b/src/utils/BatchManager.js
@@ -1,5 +1,9 @@
-function errorToSerializable(err) {
-  if (!err) return null;
+function errorToSerializable(error) {
+  // istanbul ignore next
+  if (error === undefined) throw new TypeError('No error was passed');
+
+  // make sure it is an error object so we can serialize it properly
+  const err = error instanceof Error ? error : new Error(error);
   return {
     type: err.type,
     name: err.name,
@@ -180,7 +184,7 @@ class BatchManager {
       duration: context.duration,
       statusCode: context.statusCode,
       success: context.html !== null,
-      error: errorToSerializable(context.error),
+      error: context.error ? errorToSerializable(context.error) : null,
     };
   }
 

--- a/src/utils/renderBatch.js
+++ b/src/utils/renderBatch.js
@@ -3,6 +3,7 @@ import { processBatch } from './lifecycle';
 import logger from './logger';
 
 export default (config, isClosing) => (req, res) => {
+  // istanbul ignore if
   if (isClosing()) {
     logger.info('Starting request when closing!');
   }
@@ -10,8 +11,9 @@ export default (config, isClosing) => (req, res) => {
 
   const manager = new BatchManager(req, res, jobs, config);
 
-  processBatch(jobs, config.plugins, manager)
+  return processBatch(jobs, config.plugins, manager)
     .then(() => {
+      // istanbul ignore if
       if (isClosing()) {
         logger.info('Ending request when closing!');
       }

--- a/test/renderBatch-test.js
+++ b/test/renderBatch-test.js
@@ -1,0 +1,139 @@
+import { assert } from 'chai';
+import renderBatch from '../lib/utils/renderBatch';
+
+class Response {
+  status(status) {
+    this._status = status;
+    return this;
+  }
+
+  json(res) {
+    this._json = res;
+    return this;
+  }
+
+  end() {}
+
+  getResponse() {
+    return {
+      status: this._status,
+      json: this._json,
+    };
+  }
+}
+
+class Request {
+  constructor() {
+    this.body = {
+      a: {
+        name: 'HypernovaExample',
+        data: {},
+      },
+    };
+  }
+}
+
+function makeExpress() {
+  const req = new Request();
+  const res = new Response();
+
+  return { req, res };
+}
+
+describe('renderBatch', () => {
+  it('returns a batch properly', (done) => {
+    const expressRoute = renderBatch({
+      getComponent() {
+        return null;
+      },
+      plugins: [],
+    }, () => false);
+
+    const { req, res } = makeExpress();
+
+    expressRoute(req, res).then(() => {
+      assert.isObject(res.getResponse());
+
+      const { status, json } = res.getResponse();
+
+      assert.isDefined(status);
+
+      assert.equal(status, 200);
+
+      assert.isTrue(json.success);
+      assert.isNull(json.error);
+
+      const { a } = json.results;
+      assert.isDefined(a);
+      assert.property(a, 'html');
+      assert.property(a, 'meta');
+      assert.property(a, 'duration');
+      assert.property(a, 'success');
+      assert.property(a, 'error');
+
+      done();
+    });
+  });
+
+  it('rejects a Promise with a string and its ok', (done) => {
+    const expressRoute = renderBatch({
+      getComponent() {
+        return Promise.reject('Nope');
+      },
+      plugins: [],
+    }, () => false);
+
+    const { req, res } = makeExpress();
+
+    expressRoute(req, res).then(() => {
+      const { json } = res.getResponse();
+      const { a } = json.results;
+
+      assert.equal(a.error.name, 'Error');
+      assert.equal(a.error.message, 'Nope');
+
+      done();
+    });
+  });
+
+  it('rejects a Promise with a ReferenceError', (done) => {
+    const expressRoute = renderBatch({
+      getComponent() {
+        return Promise.reject(new ReferenceError());
+      },
+      plugins: [],
+    }, () => false);
+
+    const { req, res } = makeExpress();
+
+    expressRoute(req, res).then(() => {
+      const { json } = res.getResponse();
+      const { a } = json.results;
+
+      assert.equal(a.error.name, 'ReferenceError');
+
+      done();
+    });
+  });
+
+  it('rejects a Promise with an Array', (done) => {
+    const expressRoute = renderBatch({
+      getComponent() {
+        return Promise.reject([1, 2, 3]);
+      },
+      plugins: [],
+    }, () => false);
+
+    const { req, res } = makeExpress();
+
+    expressRoute(req, res).then(() => {
+      const { json } = res.getResponse();
+      const { a } = json.results;
+
+      assert.equal(a.error.name, 'Error');
+      assert.equal(a.error.message, '1,2,3');
+
+      done();
+    });
+  });
+});


### PR DESCRIPTION
If a promise is rejected with no error now the serialization to error
won't fail because the stack is empty.

Fixes #15 and adds a few tests + regression tests.

@ljharb 