### PR TITLE
Default WORKER_COUNT to 1 when cpu count is 1

### DIFF
--- a/src/coordinator.js
+++ b/src/coordinator.js
@@ -4,7 +4,7 @@ import os from 'os';
 import logger from './utils/logger';
 import { raceTo } from './utils/lifecycle';
 
-const WORKER_COUNT = os.cpus().length - 1;
+const WORKER_COUNT = os.cpus().length - 1 || 1;
 
 function close() {
   return Promise.all(Object.values(cluster.workers).map((worker) => {


### PR DESCRIPTION
```
> let os = require('os')
undefined
> os.cpus()
[ { model: 'Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz',
    speed: 2494,
    times: 
     { user: 379945100,
       nice: 8095800,
       sys: 53693800,
       idle: 67719016300,
       irq: 9700 } } ]
> 
> os.cpus().length -1 
0
```
😅

We shouldn't assume all CPUs are declared as multicore especially when running on virtual server environments.
