### PR TITLE
Fixes exception handling stack traces

### DIFF
--- a/src/utils/BatchManager.js
+++ b/src/utils/BatchManager.js
@@ -2,8 +2,14 @@ function errorToSerializable(error) {
   // istanbul ignore next
   if (error === undefined) throw new TypeError('No error was passed');
 
-  // make sure it is an error object so we can serialize it properly
-  const err = error instanceof Error ? error : new Error(error);
+  // make sure it is an object that is Error-like so we can serialize it properly
+  // if it's not an actual error then we won't create an Error so that there is no stack trace
+  // because no stack trace is better than a stack trace that is generated here.
+  const err = (
+    Object.prototype.toString.call(error) === '[object Error]' &&
+    typeof error.stack === 'string'
+  ) ? error : { name: 'Error', type: 'Error', message: error, stack: '' };
+
   return {
     type: err.type,
     name: err.name,


### PR DESCRIPTION
On some cases we pass/throw a non-error, we used to wrap that in an
Error and then serialize that new error. The problem with that approach
is that the stack trace would be completely lost.

Now we either include the original stack trace or no stack trace at all.
Because an incorrect stack trace is worse than no stack trace.

@ljharb @lencioni 