### PR TITLE
Adds more flexibility for retrieving components

### DIFF
--- a/src/utils/BatchManager.js
+++ b/src/utils/BatchManager.js
@@ -138,7 +138,7 @@ class BatchManager {
 
     const { getComponent } = this.config;
 
-    const result = getComponent(name);
+    const result = getComponent(name, context);
 
     return Promise.resolve(result).then((renderFn) => {
       // ensure that we have this component registered


### PR DESCRIPTION
This commit passes the `context` object as a 2nd arg to
getComponent. The point of this is so that getComponent can have access
to the props objects as well as any other future items we decide
to pass into context.

@ljharb 