### PR TITLE
Changes duration to be an object

### DIFF
--- a/test/BatchManager-test.js
+++ b/test/BatchManager-test.js
@@ -147,7 +147,7 @@ describe('BatchManager', () => {
       manager.render('bar').catch(() => {
         const response = manager.getResults();
         assert.isDefined(response.results.bar.duration);
-        assert.isNumber(response.results.bar.duration);
+        assert.isObject(response.results.bar.duration);
 
         done();
       });


### PR DESCRIPTION
Rather than pass back a Number for duration which is currently the
duration for getComponent + renderToString, we now pass back an Object
which has detailed information for how long each process took.

@ljharb @lencioni 

I'd love some critical feedback on this. It seems like an innocent change but I'm not really sure if this is the right place to be handling these.

Another solution would be to expand on our plugin system and give ourselves more fine-grained control on when/what plugin lifecycle methods are called.

Currently, the only plugin lifecycle methods we can hook into are `beforeRender` and `afterRender` but a lot of stuff happens in-between.
