### PR TITLE
around_filter will be deprecated in rails 5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ Hypernova.configure do |config|
 end
 ```
 
-In your controller, you‘ll need an `:around_filter` so you can opt into Hypernova rendering of view partials.
+In your controller, you‘ll need an `:around_action` so you can opt into Hypernova rendering of view partials.
 
 ```ruby
 class SampleController < ApplicationController
-  around_filter :hypernova_render_support
+  around_action :hypernova_render_support
 end
 ```
 

--- a/examples/simple/app/controllers/welcome_controller.rb
+++ b/examples/simple/app/controllers/welcome_controller.rb
@@ -1,5 +1,5 @@
 class WelcomeController < ApplicationController
-  around_filter :hypernova_render_support
+  around_action :hypernova_render_support
   def index
   end
 end


### PR DESCRIPTION
I got error like this.

```
DEPRECATION WARNING: around_filter is deprecated and will be removed in Rails 5.1. Use around_action instead.
```

So, I think around_action is better.
If you have time, review please. 🍣 

And happy new year!! ㊗️ 