### PR TITLE
[Fix] Add return in Promise 'then' callback

### DIFF
--- a/src/utils/lifecycle.js
+++ b/src/utils/lifecycle.js
@@ -163,7 +163,7 @@ export function processJob(token, plugins, manager) {
       // afterRender
       runLifecycleSync('afterRender', plugins, manager, token);
 
-      runLifecycle('jobEnd', plugins, manager, token);
+      return runLifecycle('jobEnd', plugins, manager, token);
     })
     .catch((err) => {
       manager.recordError(err, token);
@@ -194,9 +194,7 @@ export function processBatch(jobs, plugins, manager) {
     ))
 
     // batchEnd
-    .then(() => {
-      runLifecycle('batchEnd', plugins, manager);
-    })
+    .then(() => runLifecycle('batchEnd', plugins, manager))
     .catch((err) => {
       manager.recordError(err);
       errorSync(err, plugins, manager);

--- a/src/utils/renderBatch.js
+++ b/src/utils/renderBatch.js
@@ -17,7 +17,7 @@ export default (config, isClosing) => (req, res) => {
       if (isClosing()) {
         logger.info('Ending request when closing!');
       }
-      res.status(manager.statusCode).json(manager.getResults()).end();
+      return res.status(manager.statusCode).json(manager.getResults()).end();
     })
     .catch(() => res.status(manager.statusCode).end());
 };

--- a/src/worker.js
+++ b/src/worker.js
@@ -92,6 +92,7 @@ const initServer = (app, config, callback) => {
   runAppLifecycle('initialize', config.plugins, config)
     .then(() => {
       server = app.listen(config.port, config.host, callback);
+      return null;
     })
     .catch(shutDownSequence);
 };


### PR DESCRIPTION
`return null` in Promise then callback to suppress Bluebird warning.

Though this is not required by ES6 Promise specification, this repo should comply to Bluebird best practice unless using it. Otherwise redundant log is printed out into console in development, which is annoying and have nothing to do with hypernova or its users:

<img width="1223" alt="screen shot 2017-01-19 at 10 40 03 am" src="https://cloud.githubusercontent.com/assets/4186381/22090217/ae8e7ada-de33-11e6-9e65-9133ab433b70.png">

## Documents

From Bluebird: http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it

> If you know what you're doing and don't want to silence all warnings, you can create runaway promises without causing this warning by returning e.g. null:
```js
getUser().then(function(user) {
    // Perform this in the "background" and don't care about its result at all
    saveAnalytics(user);
    // return a non-undefined value to signal that we didn't forget to return
    return null;
});
```