### PR TITLE
change welcome index to root in routes for examples/simple

### DIFF
--- a/examples/simple/config/routes.rb
+++ b/examples/simple/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  get 'welcome/index'
+  root 'welcome#index'
 
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".


### PR DESCRIPTION
I'd like to suggest a minor adjustment to examples/simple where the root route is set to welcome index.
I believe that the intent of this example is to be able to see hypernova in action for someone new to it (like me).
Through the process of making it work, one would likely encounter issues on their local development machine (such as npm and/or node versions). Once setup issues get resolved, one might still believe that something is wrong when getting the Rails page when accessing root. Consequently, such a change would make it more straightforward that everything is good to go hence driving adoption.
On a side note, I deployed the simple example to Heroku because I wanted to confirm that hypernova could be relevant for my projects deployment. This worked (see [here](https://hypernova-simple.herokuapp.com)) as follows:
1) Configure buildpacks
`heroku buildpacks:clear`
`heroku buildpacks:set heroku/nodejs`
`heroku buildpacks:add heroku/ruby --index 2`
2) Change sqlite3 to postgres
I am thinking that switching the simple example to postgres (instead of sqlite3) could be more meaningful. Would you agree?
