### PR TITLE
Make number of CPUs configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,9 @@ Options, and their defaults
   logger: {},
   // the port the app will start on
   port: 8080,
+  // function to return the number of cpus hypernova will use
+  // if not overridden, default will return the number of reported cpus  - 1
+  getCPUs: undefined,
   // default endpoint path
   endpoint: '/batch'
 }
@@ -265,6 +268,12 @@ hypernova({
   },
 });
 ```
+
+#### `getCPUs`
+
+This lets you specify the number of cores Hypernova will run workers on. Receives an argument containing the number of cores as reported by the OS.
+
+If this method is not overridden, or if a falsy value is passed, the default method will return the number of reported cores minus 1.
 
 ## API
 

--- a/src/server.js
+++ b/src/server.js
@@ -37,7 +37,7 @@ export default function hypernova(userConfig, onServer) {
   if (config.devMode) {
     worker(app, config, onServer);
   } else if (cluster.isMaster) {
-    coordinator();
+    coordinator(config.getCPUs);
   } else {
     worker(app, config, onServer, cluster.worker.id);
   }

--- a/test/coordinator-test.js
+++ b/test/coordinator-test.js
@@ -1,0 +1,43 @@
+import { assert } from 'chai';
+import os from 'os';
+import sinon from 'sinon';
+import { getDefaultCPUs, getWorkerCount } from '../lib/coordinator';
+
+describe('coordinator', () => {
+  it('default method returns correct number of cpus', () => {
+    assert.equal(getDefaultCPUs(5), 4, 'getDefaultCPUs returns n - 1 CPUs');
+
+    assert.throws(getDefaultCPUs, TypeError, 'getDefaultCPUs must accept a positive integer');
+
+    assert.throws(() => {
+      getDefaultCPUs('three');
+    }, TypeError, 'getDefaultCPUs must accept a positive integer');
+
+    assert.throws(() => {
+      getDefaultCPUs(0);
+    }, TypeError, 'getDefaultCPUs must accept a positive integer');
+  });
+
+  it('uses the correct number of cpus', () => {
+    const sandbox = sinon.sandbox.create();
+    const dummyCPUs = Array.from({ length: 5 }, () => ({}));
+    sandbox.stub(os, 'cpus').returns(dummyCPUs);
+
+    assert.equal(getWorkerCount(), dummyCPUs.length - 1, 'getWorkerCount defaults to all available cpus minus one');
+    assert.equal(getWorkerCount(() => 3), 3, 'getWorkerCount uses specified cpus');
+
+    assert.throws(() => {
+      getWorkerCount(3);
+    }, TypeError, 'getCPUs must be a function');
+
+    assert.throws(() => {
+      getWorkerCount(() => 'three');
+    }, TypeError, 'getCPUs must return a positive integer');
+
+    assert.throws(() => {
+      getWorkerCount(() => 0);
+    }, TypeError, 'getCPUs must return a positive integer');
+
+    sandbox.restore();
+  });
+});


### PR DESCRIPTION
This branch adds a `cpu` config option, to cap the number of workers Hypernova spawns

(This is desirable in deployments where we'd like to control the number of cpus per container)

Thanks!