### PR TITLE
Add option to configure host

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,13 +221,14 @@ Options, and their defaults
   devMode: false,
   // how components will be retrieved,
   getComponent: undefined,
+  // if not overridden, default will return the number of reported cpus  - 1
+  getCPUs: undefined,
+  // the host the app will bind to
+  host: '0.0.0.0',
   // configure the logger
   logger: {},
   // the port the app will start on
   port: 8080,
-  // function to return the number of cpus hypernova will use
-  // if not overridden, default will return the number of reported cpus  - 1
-  getCPUs: undefined,
   // default endpoint path
   endpoint: '/batch'
 }

--- a/src/server.js
+++ b/src/server.js
@@ -21,6 +21,7 @@ const defaultConfig = {
   logger: {},
   plugins: [],
   port: 8080,
+  host: '0.0.0.0',
 };
 
 export default function hypernova(userConfig, onServer) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -91,7 +91,7 @@ const initServer = (app, config, callback) => {
    // run through the initialize methods of any plugins that define them
   runAppLifecycle('initialize', config.plugins, config)
     .then(() => {
-      server = app.listen(config.port, callback);
+      server = app.listen(config.port, config.host, callback);
     })
     .catch(shutDownSequence);
 };


### PR DESCRIPTION
We'd like to be able to configure the host that express binds to.
This new config option passes it along, and defaults to `0.0.0.0`.