### PR TITLE
add health check endpoint (/)

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -8,11 +8,16 @@ import BatchManager from './utils/BatchManager';
 
 let closing = false;
 
+const healthCheckEndpoint = '/';
+
 const attachMiddleware = (app, config) => {
   app.use(bodyParser.json(config.bodyParser));
 };
 
 const attachEndpoint = (app, config, callback) => {
+  app.get(healthCheckEndpoint, function (req, res) {
+    res.send('It works!\n');
+  });
   app.post(config.endpoint, renderBatch(config, callback));
 };
 


### PR DESCRIPTION
We currently check the hypernova process by pid, but sometimes hypernova does not work even if the process lives.

This PR mount `/` as a health check endpoint to check the server is working or not.

What do you think of it?