### PR TITLE
Changes docs to accurately reflect devMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Options, and their defaults
   bodyParser: {
     limit: 1024 * 1000,
   },
-  // disables cluster mode and reloads each component every time it is requested
+  // runs on a single process
   devMode: false,
   // how components will be retrieved,
   getComponent: undefined,


### PR DESCRIPTION
The legacy named `devMode` has done nothing but ensure that we run on a single process since way back. This correctly describes what devMode does.

Fixes #87 