### PR TITLE
If invalid HTML is returned we reject with an err

### DIFF
--- a/src/utils/BatchManager.js
+++ b/src/utils/BatchManager.js
@@ -1,3 +1,9 @@
+const noHTMLError = new TypeError(
+  'HTML was not returned to Hypernova, this is most likely an error within your application. ' +
+  'Check your logs for any uncaught errors and/or rejections.',
+);
+noHTMLError.stack = null;
+
 function errorToSerializable(error) {
   // istanbul ignore next
   if (error === undefined) throw new TypeError('No error was passed');
@@ -153,7 +159,10 @@ class BatchManager {
       }
 
       return renderFn(context.props);
-    }).then((html) => {
+    }).then((html) => { // eslint-disable-line consistent-return
+      if (!html) {
+        return Promise.reject(noHTMLError);
+      }
       context.html = html;
       context.duration = msSince(start);
     }).catch((err) => {

--- a/test/BatchManager-test.js
+++ b/test/BatchManager-test.js
@@ -21,6 +21,10 @@ function mockPlugin() {
 const jobs = {
   foo: makeJob(),
   bar: makeJob(),
+  baz: {
+    name: 'baz',
+    data: {},
+  },
 };
 
 jobs.bar.name = 'bar'; // component not registered
@@ -29,6 +33,7 @@ const req = {};
 const res = {};
 const _strategies = {
   [COMPONENT_NAME]: sinon.stub().returns('html'),
+  baz: sinon.stub().returns(undefined),
 };
 const config = {
   getComponent(name) {
@@ -91,6 +96,16 @@ describe('BatchManager', () => {
     it('fails if component is not registered', (done) => {
       manager.render('bar').catch((err) => {
         assert.equal(err.message, 'Component "bar" not registered');
+        done();
+      });
+    });
+
+    it('fails when a component returns falsy html', (done) => {
+      manager.render('baz').catch((err) => {
+        assert.equal(
+          err.message,
+          'HTML was not returned to Hypernova, this is most likely an error within your application. Check your logs for any uncaught errors and/or rejections.',
+        );
         done();
       });
     });


### PR DESCRIPTION
As a safeguard -- in case a developer pops out of the promise chain an
error happens and Hypernova is unable to catch it -- we can detect whether
something is "off" by inspecting `html`. The html returned should be a
string and exist. If it does not exist then that's a sign that something
is wrong and needs investigation. This should prevent errors from
slipping through the cracks.