### PR TITLE
Allow a logger instance to be injected via the configuration

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -42,7 +42,7 @@ export default function hypernova(userConfig, onServer) {
     config.listenArgs = [config.port, config.host];
   }
 
-  logger.init(config.logger);
+  logger.init(config.logger, config.loggerInstance);
 
   const app = createApplication();
 

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -10,14 +10,18 @@ const OPTIONS = {
 };
 
 const loggerInterface = {
-  init(config) {
-    const options = { ...OPTIONS, ...config };
+  init(config, loggerInstance) {
+    if (loggerInstance) {
+      logger = loggerInstance;
+    } else {
+      const options = { ...OPTIONS, ...config };
 
-    logger = new winston.Logger({
-      transports: [
-        new winston.transports.Console(options),
-      ],
-    });
+      logger = new winston.Logger({
+        transports: [
+          new winston.transports.Console(options),
+        ],
+      });
+    }
 
     delete loggerInterface.init;
   },


### PR DESCRIPTION
Currently, config can specify the options to be passed to the
constructed winston logger, but the specific transport is hard coded as
Console.  Some applications may wish to use other transports like Syslog
that are defined in other packages.

This change adds a config field, `loggerInstance`, that allows an
arbitrarily constructed logger to be passed in.  Really any object that
implements `log` should work, but this is intended for other winston
loggers.

/cc @goatslacker 