### PR TITLE
Add client pyramid-hypernova

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -5,3 +5,4 @@ The following are clients in the wild for connecting to Hypernova.
 * [Node.js](https://github.com/airbnb/hypernova-node)
 * [Rails](https://github.com/airbnb/hypernova-ruby)
 * [PHP](https://github.com/wayfair/hypernova-php)
+* [Pyramid](https://github.com/Yelp/pyramid-hypernova)


### PR DESCRIPTION
We've just open sourced our client to hypernova! This is for [Pyramid](https://trypyramid.com/https://trypyramid.com/), a python web framework.

https://github.com/Yelp/pyramid-hypernova

Thanks!