### PR TITLE
Execute jobs in a batch in serial

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,9 @@ Options, and their defaults
   // the port the app will start on
   port: 8080,
   // default endpoint path
-  endpoint: '/batch'
+  endpoint: '/batch',
+  // whether jobs in a batch are processed concurrently
+  processJobsConcurrently: true,
 }
 ```
 
@@ -275,6 +277,10 @@ hypernova({
 This lets you specify the number of cores Hypernova will run workers on. Receives an argument containing the number of cores as reported by the OS.
 
 If this method is not overridden, or if a falsy value is passed, the default method will return the number of reported cores minus 1.
+
+#### `processJobsConcurrently`
+
+This determines whether jobs in a batch are processed concurrently or serially.  Serial execution is preferable if you use a renderer that is CPU bound and your plugins do not perform IO in the per job hooks.
 
 ## API
 

--- a/src/server.js
+++ b/src/server.js
@@ -22,6 +22,7 @@ const defaultConfig = {
   plugins: [],
   port: 8080,
   host: '0.0.0.0',
+  processJobsConcurrent: true,
 };
 
 export default function hypernova(userConfig, onServer) {

--- a/src/utils/lifecycle.js
+++ b/src/utils/lifecycle.js
@@ -189,8 +189,9 @@ export function processBatch(jobs, plugins, manager) {
     runLifecycle('batchStart', plugins, manager)
 
       // for each job, processJob
-      .then(() => Promise.all(
-        Object.keys(jobs).map(token => processJob(token, plugins, manager)),
+      .then(() => Object.keys(jobs).reduce(
+        (chain, token) => chain.then(() => processJob(token, plugins, manager)),
+        Promise.resolve(),
       ))
 
       // batchEnd

--- a/src/utils/renderBatch.js
+++ b/src/utils/renderBatch.js
@@ -11,7 +11,7 @@ export default (config, isClosing) => (req, res) => {
 
   const manager = new BatchManager(req, res, jobs, config);
 
-  return processBatch(jobs, config.plugins, manager)
+  return processBatch(jobs, config.plugins, manager, config.processJobsConcurrently)
     .then(() => {
       // istanbul ignore if
       if (isClosing()) {

--- a/test/renderBatch-test.js
+++ b/test/renderBatch-test.js
@@ -41,99 +41,107 @@ function makeExpress() {
 }
 
 describe('renderBatch', () => {
-  it('returns a batch properly', (done) => {
-    const expressRoute = renderBatch({
-      getComponent() {
-        return null;
-      },
-      plugins: [],
-    }, () => false);
+  [true, false].forEach((processJobsConcurrently) => {
+    describe(`when processJobsConcurrently is ${processJobsConcurrently}`, () => {
+      it('returns a batch properly', (done) => {
+        const expressRoute = renderBatch({
+          getComponent() {
+            return null;
+          },
+          plugins: [],
+          processJobsConcurrently,
+        }, () => false);
 
-    const { req, res } = makeExpress();
+        const { req, res } = makeExpress();
 
-    expressRoute(req, res).then(() => {
-      assert.isObject(res.getResponse());
+        expressRoute(req, res).then(() => {
+          assert.isObject(res.getResponse());
 
-      const { status, json } = res.getResponse();
+          const { status, json } = res.getResponse();
 
-      assert.isDefined(status);
+          assert.isDefined(status);
 
-      assert.equal(status, 200);
+          assert.equal(status, 200);
 
-      assert.isTrue(json.success);
-      assert.isNull(json.error);
+          assert.isTrue(json.success);
+          assert.isNull(json.error);
 
-      const { a } = json.results;
-      assert.isDefined(a);
-      assert.property(a, 'html');
-      assert.property(a, 'meta');
-      assert.property(a, 'duration');
-      assert.property(a, 'success');
-      assert.property(a, 'error');
+          const { a } = json.results;
+          assert.isDefined(a);
+          assert.property(a, 'html');
+          assert.property(a, 'meta');
+          assert.property(a, 'duration');
+          assert.property(a, 'success');
+          assert.property(a, 'error');
 
-      done();
-    });
-  });
+          done();
+        });
+      });
 
-  it('rejects a Promise with a string and its ok', (done) => {
-    const expressRoute = renderBatch({
-      getComponent() {
-        return Promise.reject('Nope');
-      },
-      plugins: [],
-    }, () => false);
+      it('rejects a Promise with a string and its ok', (done) => {
+        const expressRoute = renderBatch({
+          getComponent() {
+            return Promise.reject('Nope');
+          },
+          plugins: [],
+          processJobsConcurrently,
+        }, () => false);
 
-    const { req, res } = makeExpress();
+        const { req, res } = makeExpress();
 
-    expressRoute(req, res).then(() => {
-      const { json } = res.getResponse();
-      const { a } = json.results;
+        expressRoute(req, res).then(() => {
+          const { json } = res.getResponse();
+          const { a } = json.results;
 
-      assert.equal(a.error.name, 'Error');
-      assert.equal(a.error.message, 'Nope');
+          assert.equal(a.error.name, 'Error');
+          assert.equal(a.error.message, 'Nope');
 
-      done();
-    });
-  });
+          done();
+        });
+      });
 
-  it('rejects a Promise with a ReferenceError', (done) => {
-    const expressRoute = renderBatch({
-      getComponent() {
-        return Promise.reject(new ReferenceError());
-      },
-      plugins: [],
-    }, () => false);
+      it('rejects a Promise with a ReferenceError', (done) => {
+        const expressRoute = renderBatch({
+          getComponent() {
+            return Promise.reject(new ReferenceError());
+          },
+          plugins: [],
+          processJobsConcurrently,
+        }, () => false);
 
-    const { req, res } = makeExpress();
+        const { req, res } = makeExpress();
 
-    expressRoute(req, res).then(() => {
-      const { json } = res.getResponse();
-      const { a } = json.results;
+        expressRoute(req, res).then(() => {
+          const { json } = res.getResponse();
+          const { a } = json.results;
 
-      assert.equal(a.error.name, 'ReferenceError');
+          assert.equal(a.error.name, 'ReferenceError');
 
-      done();
-    });
-  });
+          done();
+        });
+      });
 
-  it('rejects a Promise with an Array', (done) => {
-    const expressRoute = renderBatch({
-      getComponent() {
-        return Promise.reject([1, 2, 3]);
-      },
-      plugins: [],
-    }, () => false);
+      it('rejects a Promise with an Array', (done) => {
+        const expressRoute = renderBatch({
+          getComponent() {
+            return Promise.reject([1, 2, 3]);
+          },
+          plugins: [],
+          processJobsConcurrently,
+        }, () => false);
 
-    const { req, res } = makeExpress();
+        const { req, res } = makeExpress();
 
-    expressRoute(req, res).then(() => {
-      const { json } = res.getResponse();
-      const { a } = json.results;
+        expressRoute(req, res).then(() => {
+          const { json } = res.getResponse();
+          const { a } = json.results;
 
-      assert.equal(a.error.name, 'Error');
-      assert.equal(a.error.message, '1,2,3');
+          assert.equal(a.error.name, 'Error');
+          assert.equal(a.error.message, '1,2,3');
 
-      done();
+          done();
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
Previously, we dispatched all jobs in a batch concurrently.  Rendering
jobs are compute bound, so we would not actually get parallel execution.
One effect of this is that timers for a job in plugins record a start
time from the point where all jobs are dispatched and record the end
time after all or most of the jobs have completely finished.  This
prevents us from being able to reliably tell how much latency a single
job contributes to the total latency (for instance, if job A takes
500ms, and job B and C each take 25ms, we may get results that would
indicate that jobs A, B, and C each spent 550ms executing, which is true
in a way, but unhelpful).

This change executes the jobs serially as a chain.

This should have no or minimal impact either way on actual response
time.

This is intended as an experiment, to see whether the above claims are true.

/cc @goatslacker @ljharb 