### PR TITLE
add support for custom logger configuration

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -3,20 +3,34 @@ import winston from 'winston';
 let logger = null;
 
 const OPTIONS = {
-  level: 'info',
-  colorize: true,
-  timestamp: true,
-  prettyPrint: process.env.NODE_ENV !== 'production',
+  transports: [
+    {
+      Console: {
+        level: 'info',
+        colorize: true,
+        timestamp: true,
+        prettyPrint: process.env.NODE_ENV !== 'production',
+      },
+    },
+  ],
+};
+
+const transportMapper = (transportConfigs) => {
+  const transportKeys = Object.keys(transportConfigs);
+
+  return transportKeys.map(transportKey =>
+    new winston.transports[transportKey](transportConfigs[transportKey]));
 };
 
 const loggerInterface = {
   init(config) {
     const options = { ...OPTIONS, ...config };
 
+    let transports = options.transports.map(transportMapper);
+    transports = [].concat(...transports);
+
     logger = new winston.Logger({
-      transports: [
-        new winston.transports.Console(options),
-      ],
+      transports,
     });
 
     delete loggerInterface.init;

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -18,16 +18,17 @@ const OPTIONS = {
 const transportMapper = (transportConfigs) => {
   const transportKeys = Object.keys(transportConfigs);
 
-  return transportKeys.map(transportKey =>
+  const transports = transportKeys.map(transportKey =>
     new winston.transports[transportKey](transportConfigs[transportKey]));
+
+  return [].concat(...transports);
 };
 
 const loggerInterface = {
   init(config) {
     const options = { ...OPTIONS, ...config };
 
-    let transports = options.transports.map(transportMapper);
-    transports = [].concat(...transports);
+    const transports = options.transports.map(transportMapper);
 
     logger = new winston.Logger({
       transports,

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -18,17 +18,16 @@ const OPTIONS = {
 const transportMapper = (transportConfigs) => {
   const transportKeys = Object.keys(transportConfigs);
 
-  const transports = transportKeys.map(transportKey =>
+  return transportKeys.map(transportKey =>
     new winston.transports[transportKey](transportConfigs[transportKey]));
-
-  return [].concat(...transports);
 };
 
 const loggerInterface = {
   init(config) {
     const options = { ...OPTIONS, ...config };
 
-    const transports = options.transports.map(transportMapper);
+    let transports = options.transports.map(transportMapper);
+    transports = [].concat(...transports);
 
     logger = new winston.Logger({
       transports,


### PR DESCRIPTION
Work in progress...

**Warning** This PR changes the logger config

- adds the ability to add custom transports with separate config for each transport -> airbnb/hypernova#64

example logger config to use in hypernova(config)
```
...
logger: {
  transports: [
    {
      Console: {
        level: 'info',
        colorize: true,
        json: false,
        prettyPrint: true,
        timestamp: true,
      },
      File: {
        filename: 'hypernova.log',
        json: false,
        prettyPrint: true,
        timestamp: true
      }
    }, 
  ],
}
...
```