### PR TITLE
Add option to pass an express instance in the configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ Options, and their defaults
   processJobsConcurrently: true,
   // arguments for server.listen, by default set to the configured [port, host]
   listenArgs: null,
+  // default function to create an express app
+  createApplication: () => express()
 }
 ```
 
@@ -303,6 +305,29 @@ hypernova({
 #### `processJobsConcurrently`
 
 This determines whether jobs in a batch are processed concurrently or serially.  Serial execution is preferable if you use a renderer that is CPU bound and your plugins do not perform IO in the per job hooks.
+
+#### `createApplication`
+This lets you provide your own function that creates an express app.
+You are able to add your own express stuff like more routes, middlewares, etc.
+Notice that you __must__ pass a function that returns an express app without calling the `listen` method!
+
+```js
+const express = require('express');
+const yourOwnAwesomeMiddleware = require('custom-middleware');
+
+hypernova({
+  createApplication: function() {
+    const app = express();
+    app.use(yourOwnAwesomeMiddleware);
+
+    app.get('/health', function(req, res) {
+      return res.status(200).send('OK');
+    });
+
+    // this is mandatory.
+    return app;
+  }
+```
 
 ## API
 

--- a/src/server.js
+++ b/src/server.js
@@ -12,6 +12,10 @@ import createVM from './createVM';
 import worker from './worker';
 import { raceTo } from './utils/lifecycle';
 
+function createApplication() {
+  return express();
+}
+
 const defaultConfig = {
   bodyParser: {
     limit: 1024 * 1000,
@@ -25,11 +29,8 @@ const defaultConfig = {
   host: '0.0.0.0',
   processJobsConcurrent: true,
   listenArgs: null,
+  createApplication,
 };
-
-function createApplication() {
-  return express();
-}
 
 export default function hypernova(userConfig, onServer) {
   const config = { ...defaultConfig, ...userConfig };
@@ -44,7 +45,11 @@ export default function hypernova(userConfig, onServer) {
 
   logger.init(config.logger, config.loggerInstance);
 
-  const app = createApplication();
+  if (typeof config.createApplication !== 'function') {
+    throw new TypeError('Hypernova requires a `createApplication` property and it must be a function that return a valid express instance');
+  }
+
+  const app = config.createApplication();
 
   if (config.devMode) {
     worker(app, config, onServer);

--- a/src/server.js
+++ b/src/server.js
@@ -46,10 +46,21 @@ export default function hypernova(userConfig, onServer) {
   logger.init(config.logger, config.loggerInstance);
 
   if (typeof config.createApplication !== 'function') {
-    throw new TypeError('Hypernova requires a `createApplication` property and it must be a function that return a valid express instance');
+    throw new TypeError('Hypernova requires a `createApplication` property which must be a function that returns an express instance');
   }
 
   const app = config.createApplication();
+
+  if (
+    typeof app !== 'function'
+    || typeof app.use !== 'function'
+    || typeof app.post !== 'function'
+    || typeof app.listen !== 'function'
+  ) {
+    throw new TypeError(
+      '`createApplication` must return a valid express instance with `use`, `post`, and `listen` methods',
+    );
+  }
 
   if (config.devMode) {
     worker(app, config, onServer);

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -60,7 +60,7 @@ describe('Hypernova server', () => {
       devMode: true,
       getComponent,
       createApplication,
-      port: 8081,
+      port: 8090,
     });
 
     assert.equal(APP_TITLE, hypernovaServer.locals.name);

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -1,13 +1,68 @@
 import { assert } from 'chai';
-
-import hypernova from '../server';
+import express from 'express';
 
 describe('Hypernova server', () => {
+  let hypernova;
+  const getComponent = () => {};
+
+  beforeEach(() => {
+    try {
+      [
+        '../lib/utils/logger.js',
+        '../lib/worker.js',
+        '../lib/server.js',
+        '../server.js',
+      ].forEach(module => delete require.cache[require.resolve(module)]);
+
+      hypernova = require('../server.js'); // eslint-disable-line global-require
+    } catch (e) {
+      console.error('Couldnt remove dependecy or load the hypernova module.');
+    }
+  });
+
   it('blows up if hypernova does not get getComponent', () => {
     assert.throws(hypernova, TypeError);
   });
 
+  it('blows up if hypernova gets `createApplication` that isnt a function', () => {
+    assert.throws(
+      () => hypernova({
+        devMode: true,
+        getComponent,
+        createApplication: {} }),
+      TypeError);
+  });
+
+  it('blows up if hypernova gets `createApplication` that doesnt return an express app', () => {
+    assert.throws(
+      () => hypernova({
+        devMode: true,
+        getComponent,
+        createApplication: () => {} }),
+      TypeError);
+  });
+
   it('starts up the hypernova server without blowing up', () => {
-    hypernova({ devMode: true, getComponent: () => {} });
+    hypernova({ devMode: true, getComponent });
+  });
+
+  it('starts up the hypernova server and an express instance without blowing up', () => {
+    const APP_TITLE = 'my custom express instance';
+
+    const createApplication = () => {
+      const app = express();
+      app.locals.name = APP_TITLE;
+
+      return app;
+    };
+
+    const hypernovaServer = hypernova({
+      devMode: true,
+      getComponent,
+      createApplication,
+      port: 8081,
+    });
+
+    assert.equal(APP_TITLE, hypernovaServer.locals.name);
   });
 });


### PR DESCRIPTION
In our project, we need to add more middlewares than just the logger to express. Hypernova starts the server automatically and returns an express instance already initialized and we cannot add middlewares afterwords. 

If we can pass the instance of express and prevent hypernova to create a new one, then we have more control over additional features to express (and maybe this is useful for other people as well). By default, if we don't pass any express instance, then hypernova will create and handle it.