### PR TITLE
worker: Add graceful shutdown

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -130,6 +130,18 @@ const worker = (app, config, onServer, workerId) => {
   // server.closing
   attachEndpoint(app, config, () => server && server.closing);
 
+  function registerSignalHandler(sig) {
+    process.on(sig, () => {
+      logger.info(`Hypernova worker got ${sig}. Going down`);
+      server.shutDownSequence();
+    });
+  }
+
+  // Gracefully shutdown the worker when not running in a cluster (devMode = true)
+  if(config.devMode) {
+    ['SIGTERM', 'SIGINT'].map(registerSignalHandler);
+  }
+
   // ===== initialize server's nuts and bolts =================================
   server = initServer(app, config, () => {
     if (process.send) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -138,7 +138,7 @@ const worker = (app, config, onServer, workerId) => {
   }
 
   // Gracefully shutdown the worker when not running in a cluster (devMode = true)
-  if(config.devMode) {
+  if (config.devMode) {
     ['SIGTERM', 'SIGINT'].map(registerSignalHandler);
   }
 


### PR DESCRIPTION
The graceful shutdown mechanism is only available for clustered installations (e.g. devMode = true). In our production stack, we are currently using multiple (HAProxy managed) single threaded instances of hypernova (e.g. devMode = true). This instances are actually systemd units so our init script is something along the lines of

```bash
# Start worker(s)
start_nova_workers() {
    for worker in $(nova_workers); do
      echo "Start ${worker}"
      systemctl start ${worker}
    done
  fi
}
```

Shutdown and restart is similar.

When we want to updated these instances, we do a rolling restart with HAProxy, which kills signals to each worker, in a round-robin manner, and re spawns it. There is a race condition in this shutdown process with open connections (as there is in the clustered version of hypernova). This patch introduces the same functionality with the single core installation.