### PR TITLE
worker: Change graceful shutdown exit code

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -133,7 +133,7 @@ const worker = (app, config, onServer, workerId) => {
   function registerSignalHandler(sig) {
     process.on(sig, () => {
       logger.info(`Hypernova worker got ${sig}. Going down`);
-      server.shutDownSequence();
+      server.shutDownSequence(null, null, 0);
     });
   }
 


### PR DESCRIPTION
Hello. Once the PR adding graceful shutdown (#147), we noticed that
the default exit code is non-zero and can affect some external systems.

Since the shutdown is graceful, it makes sense to exit the process with
0 instead of the default value (currently 1). This will help process
management software (e.g. systemd) identify that the process exited
normally.

In a side note, we could re-iterate the default exit code of
`shutDownSequence` as 0 would make more sense. I can update my
patch to reflect this changes.