### PR TITLE
Add support for AMD modules

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,5 +3,6 @@
   "plugins": [
     "add-module-exports",
     ["transform-replace-object-assign", { "moduleSpecifier": "object.assign" }],
+    "transform-es2015-modules-umd",
   ]
 }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
     "babel-plugin-transform-replace-object-assign": "^1.0.0",
     "babel-preset-airbnb": "^2.5.3",
     "chai": "^4.2.0",


### PR DESCRIPTION
This PR just adds a babel plugin to transform the library into an es2015 UMD module. That way the plugin can be used in async js loaders libraries like `require.js`.
More information about the plugin:
https://babeljs.io/docs/en/babel-plugin-transform-es2015-modules-umd