### PR TITLE
upgrade lru-cache to v5, which has been re-written with ES2015 classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "express": "^4.17.1",
     "glob": "^7.1.4",
     "has": "^1.0.3",
-    "lru-cache": "^4.1.5",
+    "lru-cache": "^5.1.1",
     "object.assign": "^4.1.0",
     "winston": "^2.4.4"
   },

--- a/src/createVM.js
+++ b/src/createVM.js
@@ -1,4 +1,4 @@
-import lruCache from 'lru-cache';
+import LRUCache from 'lru-cache';
 import crypto from 'crypto';
 import Module from './Module';
 
@@ -11,7 +11,7 @@ export default (options = {}) => {
   // This is to cache the entry point of all bundles which makes running on a vm blazing fast.
   // Everyone gets their own sandbox to play with and nothing is leaked between requests.
   // We're caching with `code` as the key to ensure that if the code changes we break the cache.
-  const exportsCache = lruCache({
+  const exportsCache = new LRUCache({
     max: options.cacheSize,
   });
 


### PR DESCRIPTION
Diff on lru-cache: https://github.com/isaacs/node-lru-cache/compare/v4.1.5...v5.1.1