### PR TITLE
Make DATA_KEY and DATA_ID attributes  importable

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,17 @@ function fromScript(attrs: Attributes): DeserializedData {}
 The inverse of `toScript`, this function runs on the browser and attempts to find and `JSON.parse` the contents of the server generated script.
 `attrs` is an object where the key will be a `data-key` to be placed on the element, and the value is the data attribute's value.
 
+The `serialize` function uses the attributes `DATA_KEY` and `DATA_ID` to generate the data markup. They can be used in the `fromScript` function to get the serialized data.
+
+```typescript
+import { DATA_KEY, DATA_ID } from 'hypernova'
+
+fromScript({
+    [DATA_KEY]: key,
+    [DATA_ID]: id,
+ });
+```
+
 ### Server
 
 #### [createGetComponent](src/createGetComponent.js)

--- a/src/index.js
+++ b/src/index.js
@@ -92,3 +92,5 @@ hypernova.toScript = toScript;
 hypernova.fromScript = fromScript;
 hypernova.serialize = serialize;
 hypernova.load = load;
+hypernova.DATA_KEY = DATA_KEY;
+hypernova.DATA_ID = DATA_ID;

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,0 +1,12 @@
+import { assert } from 'chai';
+import { DATA_KEY, DATA_ID } from '../lib';
+
+describe('hypernova', () => {
+  it('DATA_KEY constant should be importable', () => {
+    assert.equal(DATA_KEY, 'hypernova-key');
+  });
+
+  it('DATA_ID constant should be importable', () => {
+    assert.equal(DATA_ID, 'hypernova-id');
+  });
+});


### PR DESCRIPTION
*Context:*

Currently, I'm working on a framework using Hypernova and I've been writing some custom [bindings](https://github.com/ara-framework/ara-cli/wiki/Supported-Hypernova-Bindings) for other libraries like Vue.js, Svelte, etc. 

I'm getting the `data-*` values, but I think I need a way to warranty that the data attributes will be the same that `hypernova` is using if they change in the future.

https://github.com/ara-framework/hypernova-redom/blob/feat/render-client/src/index.js#L18