### PR TITLE
docs: add hypernova-vue link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ The included browser package is a barebones helper which renders markup on the s
 List of compatible browser packages:
 
 * [`hypernova-react`](https://github.com/airbnb/hypernova-react)
+* [`hypernova-vue`](https://github.com/ara-framework/hypernova-vue)
 * [`hypernova-aphrodite`](https://github.com/airbnb/hypernova-aphrodite)
 * [`hypernova-styled-components`](https://github.com/viatsko/hypernova-styled-components)
 


### PR DESCRIPTION
I added the link for `hypernova-vue`. 

[VueOnRails](https://github.com/vueonrails/vueonrails) is currently using `hypernova` and `hypernova-vue`. 

This package can be helpful to enable Vue.js developers to adopt Hypernova in their current stack.