### PR TITLE
Add "<" (&lt) to the ENCODE list

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const RIGHT = '-->';
 
 const ENCODE = [
   ['&', '&amp;'],
+  ['<', '&lt;'],
   ['>', '&gt;'],
 ];
 

--- a/test/escape-test.js
+++ b/test/escape-test.js
@@ -7,7 +7,7 @@ describe('escaping', () => {
   it('escapes', () => {
     const html = serialize('foo', '', { foo: '</script>', bar: '&gt;' });
 
-    assert.include(html, '</script&gt;');
+    assert.include(html, '&lt;/script&gt;');
     assert.include(html, '&amp;gt;');
   });
 


### PR DESCRIPTION
### What?

Also encode the `<` character in `src/index.js`.

### Why?

We have found that browsers (at least Chrome and Firefox) can interpret "/" to close a tag in a HTML comment in a script tag.

This means that a malicious attacker could submit a payload like "</script/", get it into hydration data, and prematurely close the script tag that a Hypernova comment is in, causing the page to crash.

Here's a POC (please feel free to inspect and rename it to .html if you believe I'm not giving you malware): [whoops.txt](https://github.com/airbnb/hypernova/files/4395613/whoops.txt)

```
<!DOCTYPE html5>

<body>
  <h1 id="h1">Script didn't run (bad)</h1>
  <!-- if you remove the comment line in the script the script runs as expected -->
  <script>
    <!-- {"text": "</script/"} -->
    document.getElementById("h1").innerText = "Script ran (good)"
  </script>
</body>
```

### Alternatives

Maybe we should only include `<` and drop `>` from the list if performance is a concern. Replacing the comment-in-script with `<!-- {"text": "&lt;/script>"} -->` correctly runs the script for me in Chrome, so I think escaping only `<` is acceptable.
