### PR TITLE
Fix promise global pollution

### DIFF
--- a/src/coordinator.js
+++ b/src/coordinator.js
@@ -2,6 +2,7 @@ import cluster from 'cluster';
 import os from 'os';
 
 import './environment';
+import Promise from './promise';
 import logger from './utils/logger';
 import { raceTo } from './utils/lifecycle';
 

--- a/src/environment.js
+++ b/src/environment.js
@@ -1,26 +1,2 @@
 /* eslint func-names:0 no-extra-parens:0  */
 import 'airbnb-js-shims';
-import Promise from 'bluebird';
-
-const es6methods = ['then', 'catch', 'constructor'];
-const es6StaticMethods = ['all', 'race', 'resolve', 'reject', 'cast'];
-
-function isNotMethod(name) {
-  return !(es6methods.includes(name) || es6StaticMethods.includes(name) || name.charAt(0) === '_');
-}
-
-function del(obj) {
-  /* eslint no-param-reassign: 0 */
-  return (key) => { delete obj[key]; };
-}
-
-function toFastProperties(obj) {
-  (function () {}).prototype = obj;
-}
-
-Object.keys(Promise.prototype).filter(isNotMethod).forEach(del(Promise.prototype));
-Object.keys(Promise).filter(isNotMethod).forEach(del(Promise));
-toFastProperties(Promise);
-toFastProperties(Promise.prototype);
-
-global.Promise = Promise;

--- a/src/promise.js
+++ b/src/promise.js
@@ -1,0 +1,25 @@
+/* eslint func-names:0 no-extra-parens:0  */
+import Promise from 'bluebird';
+
+const es6methods = ['then', 'catch', 'constructor'];
+const es6StaticMethods = ['all', 'race', 'resolve', 'reject', 'cast'];
+
+function isNotMethod(name) {
+  return !(es6methods.includes(name) || es6StaticMethods.includes(name) || name.charAt(0) === '_');
+}
+
+function del(obj) {
+  /* eslint no-param-reassign: 0 */
+  return (key) => { delete obj[key]; };
+}
+
+function toFastProperties(obj) {
+  (function () {}).prototype = obj;
+}
+
+Object.keys(Promise.prototype).filter(isNotMethod).forEach(del(Promise.prototype));
+Object.keys(Promise).filter(isNotMethod).forEach(del(Promise));
+toFastProperties(Promise);
+toFastProperties(Promise.prototype);
+
+export default Promise;

--- a/src/utils/BatchManager.js
+++ b/src/utils/BatchManager.js
@@ -1,3 +1,5 @@
+import Promise from '../promise';
+
 const noHTMLError = new TypeError(
   'HTML was not returned to Hypernova, this is most likely an error within your application. Check your logs for any uncaught errors and/or rejections.',
 );

--- a/src/utils/lifecycle.js
+++ b/src/utils/lifecycle.js
@@ -1,3 +1,4 @@
+import Promise from '../promise';
 import logger from './logger';
 
 const MAX_LIFECYCLE_EXECUTION_TIME_IN_MS = 300;

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,6 +1,7 @@
 import bodyParser from 'body-parser';
 
 import './environment';
+import Promise from './promise';
 import logger from './utils/logger';
 import renderBatch from './utils/renderBatch';
 import { runAppLifecycle, errorSync, raceTo } from './utils/lifecycle';


### PR DESCRIPTION
hypernova pollutes the `global.Promise` with bluebird's.
This will cause unwanted behaviors for application which uses other libraries that also use native Promise object.

This PR intends to remove direct assignment to `global.Promise` and keeps hypernova run as before by the followings:
1. Copy Promise related declaration code from environment.js to promise.js
2. Add `import Promise` statements to files which invoke Promise which will feed them with bluebird's Promise as before
3. remove Promise related code and global assignment from environment.js