### PR TITLE
Fix node v14 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 os:
  - linux
 node_js:
+  - "14"
+  - "12"
   - "11"
   - "10"
   - "8"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "has": "^1.0.3",
     "lru-cache": "^4.1.5",
     "object.assign": "^4.1.0",
-    "winston": "^2.4.4"
+    "winston": "^2.4.5"
   },
   "engines": {
     "node": ">= 0.10"


### PR DESCRIPTION
Add support for node v14
- [upgrade winston silence v14 warnings](https://github.com/winstonjs/winston/blob/2.x/CHANGELOG.md#v245)
- add testing for node v14 & v12